### PR TITLE
Update promote list to include VeSea

### DIFF
--- a/scripts/promoted.ts
+++ b/scripts/promoted.ts
@@ -1,3 +1,4 @@
 export const PROMOTED_APP_IDS: string[] = [
-    'com.vimworld.app'
+    'com.vimworld.app',
+    'io.vesea'
 ]


### PR DESCRIPTION
Adding VeSea as a promoted dApp. Hope is to have a single location linked on main discover to avoid the numerous dApps for individual projects being launched.