### PR TITLE
Correct vesea url routes

### DIFF
--- a/apps/io.vesea.galaxy/manifest.json
+++ b/apps/io.vesea.galaxy/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Galaxy Portraits NFT",
-	"href": "https://vesea.io/community/galaxy.html",
+	"href": "https://vesea.io/community/galaxy",
 	"desc": "A collection of 1099 unique galaxy themed NFT's that have been lost in space and want to find home on the Vechain Blockchain. Vesea Community Partner NFT collection.",
 	"tags": ["NFT","Galaxy","Portrait","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.guardians/manifest.json
+++ b/apps/io.vesea.guardians/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Guardians NFT",
-	"href": "https://vesea.io/community/guardians.html",
+	"href": "https://vesea.io/community/guardians",
 	"desc": "Guardians NFT is a collection of 3,000 unique warriors assembling to protect their homeland and reclaim glory for the VeChain Empire",
 	"tags": ["NFT","Guardians","Lore","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.kings/manifest.json
+++ b/apps/io.vesea.kings/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Kings of Kriptheim",
-	"href": "https://vesea.io/community/kings.html",
+	"href": "https://vesea.io/community/kings",
 	"desc": "Game pieces for VeChain's first entirely NFT tabletop game, set in the VeKing universe.",
 	"tags": ["NFT","kok","kings","vekings","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.npo/manifest.json
+++ b/apps/io.vesea.npo/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "New Pigs Order NFT",
-	"href": "https://vesea.io/community/newpigsorder.html",
+	"href": "https://vesea.io/community/newpigsorder",
 	"desc": "10k pigs randomly generated on the VeChainThor blockchain. Taking over the world one oink at a time.",
 	"tags": ["NFT","NPO","New Pigs Order","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.universe/manifest.json
+++ b/apps/io.vesea.universe/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "UniⓋerse - The Expanse Drop",
-	"href": "https://vesea.io/community/universe.html",
+	"href": "https://vesea.io/community/universe",
 	"desc": "A collection of 100 deep-space images as captured by world-renowned astrophotographers and curated by Jason Wiscovitch",
 	"tags": ["NFT","universe","astrophotography","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.veabstract/manifest.json
+++ b/apps/io.vesea.veabstract/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VeAbstract",
-	"href": "https://vesea.io/community/veabstract.html",
+	"href": "https://vesea.io/community/veabstract",
 	"desc": "A collection featuring 111 unique, abstract pieces of art created using light painting photography.",
 	"tags": ["NFT","VeAbstract","Art","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.veghosts/manifest.json
+++ b/apps/io.vesea.veghosts/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VeGhosts NFT",
-	"href": "https://vesea.io/community/veghosts.html",
+	"href": "https://vesea.io/community/veghosts",
 	"desc": "In the dark forest lie 8000 unique ghosts waiting to emerge as VeGhosts on the VeChain blockchain.",
 	"tags": ["NFT","VeGhosts","VIP-181","Collectibles"]
 }

--- a/apps/io.vesea.vegnomes/manifest.json
+++ b/apps/io.vesea.vegnomes/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "VeGnomes NFT",
-    "href": "https://vesea.io/community/vegnomes.html",
+    "href": "https://vesea.io/community/vegnomes",
     "desc": "VeGnomes - 3,333 enchanted NFT artworks depicting mystical creatures rich in culture and folklore!",
     "tags": ["NFT","VeGnomes","Gnomes","VIP-181","Collectibles","VNFT"]
 } 

--- a/apps/io.vesea.vekings/manifest.json
+++ b/apps/io.vesea.vekings/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VeKingsNFT",
-	"href": "https://vesea.io/vekings.html",
+	"href": "https://vesea.io/vekings",
 	"desc": "Your window to the VeKings NFT Universe and Marketplace",
 	"tags": ["nft","vekings","vesea","market","buy","sell","bid"]
 }

--- a/apps/io.vesea.vekongs/manifest.json
+++ b/apps/io.vesea.vekongs/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VeKongs NFT",
-	"href": "https://vesea.io/community/vekongs.html",
+	"href": "https://vesea.io/community/vekongs",
 	"desc": "1000 Unique VeKongs escaped from the jungle and are searching for a new home on the VeChain blockchain. VeSea Community Partner NFT collection.",
 	"tags": ["NFT","VeKongs","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.veloot/manifest.json
+++ b/apps/io.vesea.veloot/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "veLoot",
-	"href": "https://vesea.io/community/veloot.html",
+	"href": "https://vesea.io/community/veloot",
 	"desc": "A collection of 6,000 NFTs, each one consisting of a list of RPG-style items.",
 	"tags": ["NFT","Loot","veLoot","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.venerds/manifest.json
+++ b/apps/io.vesea.venerds/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VeNerds NFT",
-	"href": "https://vesea.io/community/venerds.html",
+	"href": "https://vesea.io/community/venerds",
 	"desc": "A collection of 5 different iconic nerds spanning 1,250 NFTs who have paved the way for the fascinating world we experience today.",
 	"tags": ["NFT","VeNerds","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.veskullz/manifest.json
+++ b/apps/io.vesea.veskullz/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VeSkullz NFT",
-	"href": "https://vesea.io/community/veskullz.html",
+	"href": "https://vesea.io/community/veskullz",
 	"desc": "VeSkullz are a collection of #666, individually designed, computer rendered skull NFTs on the VeChain blockchain.",
 	"tags": ["NFT","VeSkullz","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.veysarum/manifest.json
+++ b/apps/io.vesea.veysarum/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Veysarum NFT",
-	"href": "https://vesea.io/community/veysarum.html",
+	"href": "https://vesea.io/community/veysarum",
 	"desc": "VeSea Community Partner NFT collection. Each image contains over 3 million data points and 25 randomized variables in a physarum-based algorithm.",
 	"tags": ["NFT","Veysarum","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.victs/manifest.json
+++ b/apps/io.vesea.victs/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VICTS NFT",
-	"href": "https://vesea.io/community/victs.html",
+	"href": "https://vesea.io/community/victs",
 	"desc": "5000 inmates granted early release on to the VeChainThor blockchain.",
 	"tags": ["NFT","victs","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.vumanoids/manifest.json
+++ b/apps/io.vesea.vumanoids/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Vumanoids",
-	"href": "https://vesea.io/community/vumanoids.html",
+	"href": "https://vesea.io/community/vumanoids",
 	"desc": "Vumanoids are a collection of 7,777 humanoid PFPs! vElves, survivors the great gendercide, are the first species being introduced and they are not to be trifled with.",
 	"tags": ["NFT","Vumanoids","vElves","VIP-181","Collectibles","VNFT"]
 }


### PR DESCRIPTION
Site update removed extensions from files, so all VeSea pages ending in ".html" are 404'd. Correcting this issue.