### PR TITLE
Correct apes url

### DIFF
--- a/apps/io.vesea.madvapes/manifest.json
+++ b/apps/io.vesea.madvapes/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mad v-Apes NFT",
-	"href": "https://vesea.io/community/madvapes.html",
+	"href": "https://vesea.io/community/madvapes",
 	"desc": "A collection of 4999 MAD APES, looking for a home free of global contamination, have set up camp on one of the cleanest digital habitats: VeChainthor.",
 	"tags": ["NFT","Mad Apes","Apes","VIP-181","Collectibles","VNFT"]
 }

--- a/apps/io.vesea.venerds/manifest.json
+++ b/apps/io.vesea.venerds/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "VeNerds NFT",
-	"href": "https://vesea.io/community/venerds.html",
+	"href": "https://vesea.io/community/venerds",
 	"desc": "A collection of 5 different iconic nerds spanning 1,250 NFTs who have paved the way for the fascinating world we experience today.",
 	"tags": ["NFT","VeNerds","VIP-181","Collectibles","VNFT"]
 }


### PR DESCRIPTION
Site update removed extensions from files, so all VeSea pages ending in ".html" are 404'd. Correcting this issue.