### PR TITLE
Correct readme JSON syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Create a `manifest.json` file includes app details.
     "name": "your app name",
     "href": "https://link-to-your-app",
     "desc": "This is an awesome app",
-    "category": "utilities"
+    "category": "utilities",
     "tags": ["tools","development"],
     "repo": "https://github.com/example/projectName",
     "contracts": [


### PR DESCRIPTION
JSON example in readme is missing a comma and will cause validation failure if copied by submitters