### PR TITLE
Update Address Regex to Allow Uppercase Hex Characters

### DIFF
--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -9,7 +9,7 @@ import axios from 'axios'
 
 const bundleName = /^(([a-z0-9\-]+\.)+)[a-z0-9\-]+$/
 const url = /^(http(s?):\/\/)([a-zA-Z0-9.-]+)(:[0-9]{1,4})?/
-const address = /^0x[a-f0-9]{40}$/
+const address = /^0x[a-fA-F0-9]{40}$/
 const category = /collectibles|defi|games|marketplaces|utilities/
 
 class ValidationError extends Error {


### PR DESCRIPTION
This will allow people to submit checksum versions of their contract address.

i.e. `0x24Ee6E8D0ffCcA3D73EADA5c8585301F2BC10d60` == `0x24ee6e8d0ffcca3d73eada5c8585301f2bc10d60`

Both are equally reachable.