### PR TITLE
Upadate EVearn's URL

### DIFF
--- a/apps/io.evearn/manifest.json
+++ b/apps/io.evearn/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "EVearn",
-  "href": "https://evearn.io/",
+  "href": "https://app.evearn.io/",
   "desc": "Earn rewards for charging your Tesla and reducing your carbon footprint.",
   "category": "defi",
   "tags": ["dapp", "sustainability"],


### PR DESCRIPTION
- Updated EVearn's URL to https://app.evearn.io/