### PR TITLE
fix: removed governance app from the VeBetterDAO app name

### DIFF
--- a/apps/org.vebetterdao.governance/manifest.json
+++ b/apps/org.vebetterdao.governance/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "VeBetterDAO governance app",
+    "name": "VeBetterDAO",
     "href": "https://governance.vebetterdao.org",
     "desc": "Vote for your favourite sustainability dApps in VeBetterDAO’s governance.",
     "category": "defi",


### PR DESCRIPTION
Removed the **governance app** from the VeBetterDAO name on app hub