### PR TITLE
feat: add sustainability category and reclassify VeBetterDAO apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Create a `manifest.json` file includes app details.
 - defi
 - games
 - marketplaces
+- sustainability
 - utilities
 
 ### VeBetterDAO ID

--- a/apps/ai.nubila/manifest.json
+++ b/apps/ai.nubila/manifest.json
@@ -2,7 +2,7 @@
     "name":"Nubila",
     "href":"https://nubila.ai/vbd",
     "desc":"Nubila is an innovative DePIN network that helps users earn rewards by collecting real-time hyperlocal weather data through decentralized weather devices and verifying the authenticity and validity of the data on the network.",
-    "category":"defi",
+    "category":"sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/com.b3dtime/manifest.json
+++ b/apps/com.b3dtime/manifest.json
@@ -2,7 +2,7 @@
   "name": "B3DTIME",
   "href": "https://www.b3dtime.com",
   "desc": "Sleep better, earn rewards. B3DTIME is the sleep-to-earn dApp that rewards users with $B3TR tokens for healthy sleep habits. Connect your wearable and get rewarded daily.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x469a6275cf47638311f2749227c938f4c4fd7a3988ab178b6132aa2ed57bddf0"

--- a/apps/com.b3trtransit/manifest.json
+++ b/apps/com.b3trtransit/manifest.json
@@ -2,7 +2,7 @@
     "name": "B3TR Transit",
     "href": "https://b3trtransit.com",
     "desc": "B3TR Transit is a \"Ride-to-Earn\" dApp designed to address urban pollution and congestion by incentivizing public transportation usage. Powered by VeChain and integrated with VeBetterDAO (VBD), B3TR Transit rewards users with $B3TR tokens for every verifiable eco-commute. By gamifying sustainability and making environmental action financially rewarding, B3TR Transit aims to transform daily travel habits and foster a greener future.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": ["sustainability","eco-ride", "ride-to-earn"],
     "isVeWorldSupported": true,
     "veBetterDaoId": "0xf9f69150ff561161465395d5581cf41173877f057cc4323a074e9638e077f37e"

--- a/apps/com.b3ttery.hyenaworks.xyz/manifest.json
+++ b/apps/com.b3ttery.hyenaworks.xyz/manifest.json
@@ -2,7 +2,7 @@
     "name": "B3TTERY",
     "href": "https://b3ttery.hyenaworks.xyz/",
     "desc": "An AI-powered DApp that promotes smart and sustainable charging.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability",

--- a/apps/com.bikademy.app/manifest.json
+++ b/apps/com.bikademy.app/manifest.json
@@ -2,7 +2,7 @@
     "name": "BIKADEMY",
     "href": "https://vechain.bike/",
     "desc": "Ride your bike, earn $B3TR. Bikademy is a cycle-to-earn app that rewards real-world cycling. Track your rides, compete in global Challenges, and get rewarded.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": ["dapp", "sustainability", "lifestyle", "cycling", "move"],
     "isVeWorldSupported": true,
     "veBetterDaoId": "0x2774c32e40cb4ee2d6a53abe456934b0b2d39c512f8173a7472daa19050480d4"

--- a/apps/com.bybgym/manifest.json
+++ b/apps/com.bybgym/manifest.json
@@ -2,7 +2,7 @@
     "name": "BYB - Build Your Body",
     "href": "https://bybgym.com",
     "desc": "BYB makes every workout count by rewarding you for your effort. Push yourself through workouts, complete challenges, and earn exciting rewards as you level up. With each session, you’ll unlock achievements that keep you motivated and moving forward. Whether you're a beginner or a seasoned athlete, BYB offers a fun, engaging way to track your progress and reach your fitness goals - Build sweat, build rewards, build your body.\n ",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/com.eatup.vet/manifest.json
+++ b/apps/com.eatup.vet/manifest.json
@@ -2,7 +2,7 @@
     "name": "Eat Up",
     "href": "https://h5.eatup.vet/",
     "desc": "Eat Up is an environmental initiative that utilizes a photo-based check-in mechanism to reduce food waste. Data indicates that reducing 1kg of food waste can decrease approximately 2.5kg of carbon dioxide emissions. This dapp is designed for users to photograph and upload their empty plates after meals. And after the upload is verified by AI, users receive certain B3TR incentives. The reward distribution rules are further integrated with progression-based game-like mechanics, thereby enhancing the user check-in experience and promoting sustained participation in the campaign.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/com.gopaperoo.xyz/manifest.json
+++ b/apps/com.gopaperoo.xyz/manifest.json
@@ -2,7 +2,7 @@
     "name": "GoPaperoo!",
     "href": "https://gopaperoo.xyz/",
     "desc": "GoPaperoo!, created under the leadership of GoPer, is a fun and sustainability-driven app that encourages users to skip ATM receipts and help protect trees by reducing unnecessary paper waste.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "NFT",
         "dapp",

--- a/apps/com.groncard.www/manifest.json
+++ b/apps/com.groncard.www/manifest.json
@@ -2,7 +2,7 @@
   "name": "GronCard",
   "href": "https://www.groncard.com",
   "desc": "GronCard is the easiest way to use your B3TR in everyday life. In just a few clicks, you can turn your tokens into gift cards for your favorite brands like Amazon, Netflix, and Spotify — making crypto simple, rewarding, and part of your daily routine.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0xbf700a9877e9733e70c03488e6b9e9560c4f6f68c64db5662ecb4ed6c960bbfe"

--- a/apps/com.groncard.www/manifest.json
+++ b/apps/com.groncard.www/manifest.json
@@ -2,7 +2,7 @@
   "name": "GronCard",
   "href": "https://www.groncard.com",
   "desc": "GronCard is the easiest way to use your B3TR in everyday life. In just a few clicks, you can turn your tokens into gift cards for your favorite brands like Amazon, Netflix, and Spotify — making crypto simple, rewarding, and part of your daily routine.",
-  "category": "sustainability",
+  "category": "defi",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0xbf700a9877e9733e70c03488e6b9e9560c4f6f68c64db5662ecb4ed6c960bbfe"

--- a/apps/com.likapa.avoco/manifest.json
+++ b/apps/com.likapa.avoco/manifest.json
@@ -2,7 +2,7 @@
     "name": "Avoco",
     "href": "https://avoco.app",
     "desc": "Avoco is designed to encourage healthy, balanced eating while promoting eco-conscious habits through mindful food choices that reduce environmental impact.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability",

--- a/apps/com.pauseyourcarbon/manifest.json
+++ b/apps/com.pauseyourcarbon/manifest.json
@@ -2,7 +2,7 @@
   "name": "Pause your carbon",
   "href": "https://pauseyourcarbon.com/",
   "desc": "Earn rewards for buying back your carbon footprint.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0xe19c5e83670576cac1cee923e1f92990387bf701af06ff3e0c5f1be8d265c478"

--- a/apps/com.plant2earn.xyz/manifest.json
+++ b/apps/com.plant2earn.xyz/manifest.json
@@ -2,7 +2,7 @@
     "name": "Plant To Earn",
     "href": "https://plant2earn.xyz",
     "desc": "Take a photo while watering your houseplants or garden, let our AI analyze it, and earn B3TR tokens! Give life to plants, give back to nature. Grow, earn, make a difference.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": ["plants","lifestyle", "water-to-earn", "sustainability"],
     "isVeWorldSupported": true,
     "veBetterDaoId": "0x903311aa8a76fae3d4b3a405f5d4eddf2e2a807d4f8f1eb607351aef1ac0776a"

--- a/apps/com.snapbox.online/manifest.json
+++ b/apps/com.snapbox.online/manifest.json
@@ -2,7 +2,7 @@
     "name": "SnapBox",
     "href": "https://snapbox.online",
     "desc": "SnapBox is a community-driven platform where users share photos of their portable meals stored in reusable containers. Whether it's a lunch packed for work, school, or outdoor adventures, SnapBox encourages users to snap and upload their eco-friendly food moments. The app promotes healthy eating habits and sustainability, aiming to help reduce carbon emissions by encouraging reusable packaging and mindful eating. Each snap, submitted once every 24 hours, is analyzed by AI and rewarded with a certain amount of B3TR tokens.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [ "sustainability", "lifestyle", "food", "reusable-containers"],
     "isVeWorldSupported": true,
     "veBetterDaoId": "0x991c0c9b323be86bfcabba249fddf32a7f2a04baeba50e0690ec8362a7b68504"

--- a/apps/com.vyvo.www/manifest.json
+++ b/apps/com.vyvo.www/manifest.json
@@ -2,7 +2,7 @@
   "name": "Vyvo",
   "href": "https://vyvo.com",
   "desc": "Experience the health revolution with Vyvo Smart Chain, where blockchain, IoT, and AI unite to transform how we manage well-being. We inspire individuals to actively monitor their health and, in return, reward them.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0xa30ddd53895674f3517ed4eb8f7261a4287ec1285fdd13b1c19a1d7009e5b7e3"

--- a/apps/com.walkie.space/manifest.json
+++ b/apps/com.walkie.space/manifest.json
@@ -2,7 +2,7 @@
     "name": "Walkie",
     "href": "https://walkie.space",
     "desc": "Walk more, earn more! Simply take a photo of your daily step count displayed on your smartwatch screen and upload it to the Walkie dapp. Get rewarded with $B3TR for every verified movement you make.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": ["dapp","lifestyle", "walk", "sustainability"],
     "isVeWorldSupported": true,
     "veBetterDaoId": "0xa16434dcc9849d2c1394ebf6d2e2f5ac71056bdbd7c45b40dded18fcdc4077c9"

--- a/apps/com.wattly-app/manifest.json
+++ b/apps/com.wattly-app/manifest.json
@@ -2,7 +2,7 @@
     "name": "Wattly",
     "href": "https://wattly-app.com",
     "desc": "Cut down your screen time and earn B3TR rewards",
-    "category": "defi",
+    "category": "sustainability",
     "tags": ["dapp", "sustainability"],
     "isVeWorldSupported": true,
     "veBetterDaoId": "0xecb83100aeb99560b756db29ae6f9b9d95150a285c0d6f13aecf05bb2e97ccaa"

--- a/apps/green.bubbles/manifest.json
+++ b/apps/green.bubbles/manifest.json
@@ -2,7 +2,7 @@
     "name":"Bubbles",
     "href":"https://bubbles.green",
     "desc":"Refill. Scan. Earn.\n\nBUBBLES tracks the use of refillable water bottles and rewards users for sustainable behavior. Each verified scan helps reduce CO₂ by replacing single-use plastic bottles.\n\nEach scan helps cut CO₂ emissions, replacing single-use plastic bottles and lowering your electricity footprint, turning your everyday choices into measurable climate action.",
-    "category":"defi",
+    "category":"sustainability",
     "tags":  [
         "dapp",
         "sustainability"

--- a/apps/io.dappies/manifest.json
+++ b/apps/io.dappies/manifest.json
@@ -2,7 +2,7 @@
     "name": "Dappies",
     "href": "https://app.dappies.io",
     "desc": "Complete challenges across the VeBetter universe: shop sustainably with GreenCart, ditch single-use cups with Mugshot, clean up your neighbourhood with Cleanify and more; watch your Dappy evolve as you rack up verified, on-chain proof of your real-world impact.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/io.evearn/manifest.json
+++ b/apps/io.evearn/manifest.json
@@ -2,7 +2,7 @@
   "name": "Evearn",
   "href": "https://evearn.io",
   "desc": "Evearn turns electric and hybrid driving into rewards. Every kilometer you drive contributes to a more sustainable future. With simple login, seamless vehicle integration, and an intuitive interface, participating in clean mobility is effortless.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x6c977a18d427360e27c3fc2129a6942acd4ece2c8aaeaf4690034931dc5ba7f9"

--- a/apps/life.nopaper/manifest.json
+++ b/apps/life.nopaper/manifest.json
@@ -2,7 +2,7 @@
   "name": "NoPaper",
   "href": "https://nopaper.life",
   "desc": "Shop and Earn!, Your groceries, now rewarding the planet.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": [
     "dapp",
     "sustainability"

--- a/apps/me.mendify/manifest.json
+++ b/apps/me.mendify/manifest.json
@@ -2,7 +2,7 @@
     "name": "Mendify",
     "href": "https://www.mendify.me",
     "desc": "Don’t throw it away — fix it with Mendify! Earn B3TR rewards for your repairs while making a real impact on sustainability.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/org.carbonlarity.dapp/manifest.json
+++ b/apps/org.carbonlarity.dapp/manifest.json
@@ -2,7 +2,7 @@
     "name":"Carbonlarity",
     "href":"https://dapp.carbonlarity.org",
     "desc":"Carbonlarity is a ReFi and DePin platform addressing carbon traceability in different scenarios. We combine blockchain technology with advanced IoT solutions to promote sustainability through real-time electricity monitoring and control.",
-    "category":"defi",
+    "category":"sustainability",
     "tags":  [
         "dapp",
         "sustainability"

--- a/apps/org.hangndry/manifest.json
+++ b/apps/org.hangndry/manifest.json
@@ -2,7 +2,7 @@
     "name": "HangnDry",
     "href": "https://hangndry.org",
     "desc": "HangnDry your laundry to save energy and get rewarded for skipping the dryer. It's a simple, satisfying way to live more sustainably cutting carbon emissions, lowering electricity use, and extending the life of your clothes. Whether you dry indoors on a rack or outdoors in the breeze, HangnDry turns everyday laundry into meaningful climate action.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/site.b3trsmile/manifest.json
+++ b/apps/site.b3trsmile/manifest.json
@@ -2,7 +2,7 @@
   "name": "B3TR Smile",
   "href": "https://b3trsmile.site",
   "desc": "B3TR Smile turns your daily toothbrushing into a way to protect the planet. 🌍 By encouraging you to use just one glass of water instead of running the tap, the app helps save water, reduce energy use, and lower your carbon footprint. Simply share a quick photo before brushing, let our AI verify it, and earn weekly rewards for your eco-friendly habit. Brush smarter, save water, smile brighter!",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x3838203fad0b4e194673009af3231e4b0fe69065e865bb95ff1c080bfdd175b9"

--- a/apps/vet.betterbag/manifest.json
+++ b/apps/vet.betterbag/manifest.json
@@ -2,7 +2,7 @@
     "name":"BetterBag",
     "href":"https://betterbag.vet",
     "desc":"Say goodbye to plastic and hello to rewards with BetterBag! 🌍♻️ Every time you shop with a reusable bag, you earn $B3TR! Join a growing community of conscious shoppers, reduce plastic waste, and make a positive impact in the world!",
-    "category":"defi",
+    "category":"sustainability",
     "tags":  [
         "dapp",
         "sustainability"

--- a/apps/vet.bettermode/manifest.json
+++ b/apps/vet.bettermode/manifest.json
@@ -2,7 +2,7 @@
     "name":"BetterMode",
     "href":"https://bettermode.vet",
     "desc":"Run your appliances smarter and get rewarded with $B3TR! 🌱⚡ Every time you use your dishwasher or washing machine in eco mode, you earn rewards! Save energy, lower your carbon footprint, and turn sustainability into rewards. Join the movement and make every wash count! 💚",
-    "category":"defi",
+    "category":"sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/vet.bigbottle.app/manifest.json
+++ b/apps/vet.bigbottle.app/manifest.json
@@ -2,7 +2,7 @@
     "name": "BigBottle",
     "href": "https://app.bigbottle.vet",
     "desc": "A small choice, a big impact. 👍\nEvery time you choose a large bottle over a small one,\nyou're cutting plastic waste — right at the source.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/vet.bitegram/manifest.json
+++ b/apps/vet.bitegram/manifest.json
@@ -2,7 +2,7 @@
   "name": "BiteGram",
   "href": "https://app.bitegram.vet",
   "desc": "Say hello to healthy eating habits and real rewards with BiteGram! 🥗📱 Just snap a photo of your meal and earn B3TR tokens for making nutritious choices. Join the movement to eat better, get rewarded, and make a sustainable impact—one bite at a time!",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x1607a4bafb42b7a31e43b3819033a70bf042c26cbb2d7dd173662413e4637c85"

--- a/apps/vet.byebyebites/manifest.json
+++ b/apps/vet.byebyebites/manifest.json
@@ -2,7 +2,7 @@
   "name": "Bye Bye Bites",
   "href": "https://app.byebyebites.vet",
   "desc": "Say goodbye to food waste and hello to rewards with Bye Bye Bites! 🥕🛒 Just snap a photo of groceries close to expiring and earn $B3TR for saving good food from going to waste. Join the movement to fight food waste, earn rewards, and make a sustainable impact—one bite at a time!",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0xa0ec8929ae5cc30449bab1cbc691363807dd6863b2cdddfaf575c70e055978b9"

--- a/apps/vet.cleanify/manifest.json
+++ b/apps/vet.cleanify/manifest.json
@@ -2,7 +2,7 @@
   "name": "Cleanify",
   "href": "https://app.cleanify.vet",
   "desc": "A new way to earn, while solving old problems. ♻️ Cleanify rewards sustainable actions that keep our world clean",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x899de0d0f0b39e484c8835b2369194c4c102b230c813862db383d44a4efe14d3"

--- a/apps/vet.ecobag/manifest.json
+++ b/apps/vet.ecobag/manifest.json
@@ -2,7 +2,7 @@
     "name": "ecobag",
     "href": "https://ecobag.solutions/",
     "desc": "EcoBag.vet is a community-powered DApp that rewards eco-conscious shoppers with B3TR tokens for making sustainable choices. Simply upload a picture of your reusable bag and receipt after shopping to earn rewards while reducing plastic waste. Built on VeChain and powered by VeBetterDAO, EcoBag.vet tracks your positive impact and offers real-world benefits, including redeemable NFTs for EcoBags. Join the movement toward a cleaner, greener future-one bag at a time.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/vet.ecomeal/manifest.json
+++ b/apps/vet.ecomeal/manifest.json
@@ -2,7 +2,7 @@
   "name": "EcoMeal",
   "href": "https://ecomeal.vet",
   "desc": "Snap a photo of your plastic-free meal, share it with the community, and earn rewards for making sustainable food decisions.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x54ac74eb150845171b72562f7d091cfbd3a20af91f21d26a2e9c5c97341c97c6"

--- a/apps/vet.greencart/manifest.json
+++ b/apps/vet.greencart/manifest.json
@@ -2,7 +2,7 @@
   "name": "Greencart",
   "href": "https://app.greencart.ai",
   "desc": "Shop, Scan, Earn! Turn your grocery receipts into rewards with our sustainable shopping app. Make every purchase count for a greener future.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x9643ed1637948cc571b23f836ade2bdb104de88e627fa6e8e3ffef1ee5a1739a"

--- a/apps/vet.justote/manifest.json
+++ b/apps/vet.justote/manifest.json
@@ -2,7 +2,7 @@
   "name": "JusTote",
   "href": "https://justote.vet",
   "desc": "Just Tote. Get Rewarded. Skip the plastic—just tote your reusable bag, upload your receipt, and earn rewards for making eco-friendly choices. It’s simple, smart, and good for the planet. Start earning with JusTote today!",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x590839c4641c4b5934760f3237da1de3dfd5f38d078d9fecedecf8bc5b572b2b"

--- a/apps/vet.metermate/manifest.json
+++ b/apps/vet.metermate/manifest.json
@@ -2,7 +2,7 @@
     "name": "MeterMate",
     "href": "https://metermate.vet",
     "desc": "Monitoring, insights, and rewards for reducing the environmental impact of your home",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/vet.mugshot/manifest.json
+++ b/apps/vet.mugshot/manifest.json
@@ -2,7 +2,7 @@
   "name": "Mugshot",
   "href": "https://mugshot.vet",
   "desc": "Innovative dApp dedicated to revolutionize the way coffee enthusiasts approach sustainability in their daily coffee consumption.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x2fc30c2ad41a2994061efaf218f1d52dc92bc4a31a0f02a4916490076a7a393a"

--- a/apps/vet.nanoact/manifest.json
+++ b/apps/vet.nanoact/manifest.json
@@ -2,7 +2,7 @@
   "name": "NanoAct",
   "href": "https://nanoact.vet",
   "desc": "Support local small businesses and your community.",
-  "category": "defi",
+  "category": "sustainability",
   "tags": [
     "dapp",
     "sustainability"

--- a/apps/vet.powerup.app/manifest.json
+++ b/apps/vet.powerup.app/manifest.json
@@ -2,7 +2,7 @@
     "name": "Power Up!",
     "href": "https://app.powerup.vet",
     "desc": "Power Up! is a revolutionary platform that helps individuals and businesses track and optimize their energy consumption while earning rewards for sustainable choices.",
-    "category": "defi",
+    "category": "sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/apps/vet.scoopup/manifest.json
+++ b/apps/vet.scoopup/manifest.json
@@ -2,7 +2,7 @@
     "name": "ScoopUp",
     "href": "https://scoopup.vet",
     "desc": "Rewarding dog owners to clean up wayward dog poop in their neighborhoods. Join us on our mission to reduce waste and create healthier and safer environments for our local communities. Scoop the poop. Make a difference!",
-    "category": "defi",
+    "category": "sustainability",
     "tags": ["dapp", "sustainability"],
     "isVeWorldSupported": true,
     "veBetterDaoId": "0x2e5953bbae7b743fe287d62e3a2d54d250b3e569de1052ebdde7df247a47fc43"

--- a/apps/vet.solarwise.app/manifest.json
+++ b/apps/vet.solarwise.app/manifest.json
@@ -2,7 +2,7 @@
   "name": "Solarwise",
   "href": "https://app.solarwise.vet",
   "desc": "Tokenizing Real-World Solar Projects: Earn Rewards from Electricity Sales with SolarWise!",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability", "nft"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x1cdf0d2cc9bb81296647c3b6baae1006471a719e67c6431155db920d71242afb"

--- a/apps/vet.solarwise.app/manifest.json
+++ b/apps/vet.solarwise.app/manifest.json
@@ -2,7 +2,7 @@
   "name": "Solarwise",
   "href": "https://app.solarwise.vet",
   "desc": "Tokenizing Real-World Solar Projects: Earn Rewards from Electricity Sales with SolarWise!",
-  "category": "sustainability",
+  "category": "defi",
   "tags": ["dapp", "sustainability", "nft"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x1cdf0d2cc9bb81296647c3b6baae1006471a719e67c6431155db920d71242afb"

--- a/apps/vet.st3pr/manifest.json
+++ b/apps/vet.st3pr/manifest.json
@@ -2,7 +2,7 @@
   "name": "ST3PR",
   "href": "https://st3pr.vet",
   "desc": "The Walk-2-Earn Dapp",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x698555a1fc7b34a52900e3df2d68dd380fa3dfae3b3ed65dba0d230cdab17689"

--- a/apps/vet.trashdash/manifest.json
+++ b/apps/vet.trashdash/manifest.json
@@ -2,7 +2,7 @@
   "name": "TrashDash",
   "href": "https://app.trashdash.vet",
   "desc": "Recycle, compost, and earn rewards with TrashDash! Just snap a photo of your waste, and our AI will detect if it’s recyclable or compostable. If it is, you’ll score $B3TR for doing your part to protect the planet. Turn everyday actions into impact and make sustainability part of your daily routine with TrashDash!",
-  "category": "defi",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x00352db25893ff522b6b0a46cb616bbed98886403dbf6f0543f80d214f993ba8"

--- a/apps/vet.verecycle/manifest.json
+++ b/apps/vet.verecycle/manifest.json
@@ -2,7 +2,7 @@
     "name":"VeRecycle",
     "href":"https://verecycle.vet",
     "desc":"Turn recycling into rewards with VeRecycle! Simply return your bottles to deposit machines, take a pic of the receipt, and earn $B3TR! Join the VeRecycle community today and start making a positive impact on the planet, one bottle at a time! 🌍♻️💰",
-    "category":"defi",
+    "category":"sustainability",
     "tags": [
         "dapp",
         "sustainability"

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -11,7 +11,7 @@ const bundleName = /^(([a-z0-9\-]+\.)+)[a-z0-9\-]+$/
 const url = /^(http(s?):\/\/)([a-zA-Z0-9.-]+)(:[0-9]{1,4})?/
 const address = /^0x[a-f0-9]{40}$/
 const byte32 = /^0x[a-f0-9]{64}$/
-const category = /collectibles|defi|games|marketplaces|utilities/
+const category = /collectibles|defi|games|marketplaces|sustainability|utilities/
 
 class ValidationError extends Error {
     constructor(message: string) {


### PR DESCRIPTION
## Summary

1. Adds `sustainability` to the list of accepted manifest categories (`scripts/validate.ts` + `README.md`).
2. Reclassifies 41 VeBetterDAO X2Earn apps from `defi` → `sustainability`, since they were only tagged `defi` for lack of a better fit.

## Motivation

A large share of new VeBetterDAO X2Earn apps are sustainability-focused (carbon offsetting, recycling, eco-friendly behaviour rewards, etc.). With no fitting category, many of them ended up tagged as `defi`, which makes the directory harder to browse and misrepresents the apps. A dedicated `sustainability` category lets these submissions be classified accurately.

## VeBetterDAO apps kept as `defi`

These are actual DeFi products (DEX, finance, delegation, derivatives, tokenized assets), not sustainability apps:

- BetterSwap
- GronCard (B3TR → gift cards)
- Juicy Finance
- Solarwise (tokenizes real-world solar projects)
- Turtle Swap
- veDelegate.vet
- VeSwap
- VeTrade

Non-VeBetterDAO defi apps (e.g. Wanchain bridge) are unaffected. VeBetterDAO apps already classified under `games` / `marketplaces` / `utilities` (e.g. Green Ambassador Challenge, WoV Marketplace, Arbor) are left unchanged — those categories are accurate.

## Reclassified to `sustainability` (41)

ai.nubila, com.b3dtime, com.b3trtransit, com.b3ttery.hyenaworks.xyz, com.bikademy.app, com.bybgym, com.eatup.vet, com.gopaperoo.xyz, com.likapa.avoco, com.pauseyourcarbon, com.plant2earn.xyz, com.snapbox.online, com.vyvo.www, com.walkie.space, com.wattly-app, green.bubbles, io.dappies, io.evearn, life.nopaper, me.mendify, org.carbonlarity.dapp, org.hangndry, site.b3trsmile, vet.betterbag, vet.bettermode, vet.bigbottle.app, vet.bitegram, vet.byebyebites, vet.cleanify, vet.ecobag, vet.ecomeal, vet.greencart, vet.justote, vet.metermate, vet.mugshot, vet.nanoact, vet.powerup.app, vet.scoopup, vet.st3pr, vet.trashdash, vet.verecycle.

## Follow-up

A companion PR is open at vechain/app-hub-app#31 so the new category renders in the sidebar of https://apps.vechain.org once this PR is published.

## Test plan

- [x] `npm run validate` passes locally (157 apps)
- [ ] Workflow CI passes (note: the standard "submit only one app at a time" PR check may need a maintainer override since this is a bulk maintenance change, not an app submission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)