### PR TITLE
fix: set zeloop spotter category to sustainability

### DIFF
--- a/apps/net.zeloop.spotter/manifest.json
+++ b/apps/net.zeloop.spotter/manifest.json
@@ -2,7 +2,7 @@
   "name": "A ZeLoop Spotter",
   "href": "https://spotter.zeloop.net/",
   "desc": "🔎♻️Spot, Snap & Win for the planet",
-  "category": "recycling",
+  "category": "sustainability",
   "tags": ["dapp", "sustainability"],
   "isVeWorldSupported": true,
   "veBetterDaoId": "0x5bb2ef79e3b23a39d13b02cea56780627ce65664e1cb037232a615583f6c4d77"


### PR DESCRIPTION
## Summary
- ZeLoop Spotter (#455) was merged with `"category": "recycling"`, which is not in the validator's allowlist (`collectibles|defi|games|marketplaces|sustainability|utilities`).
- This is currently breaking the build on `master` (`npm run validate` fails with `check net.zeloop.spotter -> invalid category`).
- Aligning the category to `sustainability`, which is already in this app's `tags`.

## Test plan
- [x] `npm run validate` passes locally (159 apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)